### PR TITLE
 minor-db-naming-suggestion

### DIFF
--- a/Week 10 Animal Sighting/server/db/db.sql
+++ b/Week 10 Animal Sighting/server/db/db.sql
@@ -24,6 +24,7 @@ CREATE TABLE individuals (
     created_at TIMESTAMP DEFAULT NOW()
 );
 
+-- In the future maybe for location rename to something different, it looks like it could potentially be a keyword.
 -- Create the sightings table
 CREATE TABLE sightings (
     id SERIAL PRIMARY KEY,


### PR DESCRIPTION
I noticed that in your table where you named location, it looked like it was a keyword, maybe in the future, try sighting_location